### PR TITLE
Allow empty telegram handle to pass validity test

### DIFF
--- a/src/main/java/seedu/address/model/person/TelegramHandle.java
+++ b/src/main/java/seedu/address/model/person/TelegramHandle.java
@@ -38,7 +38,7 @@ public class TelegramHandle {
      * Returns true if a given string is a valid Telegram handle.
      */
     public static boolean isValidHandle(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.isEmpty() || test.matches(VALIDATION_REGEX);
     }
 
     @Override


### PR DESCRIPTION
Fixes loading of empty telegram handles, so that it can be loaded into a valid state with an indication that no actual handle is present