### PR TITLE
Update shadowJar archive filename

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 }
 
 shadowJar {
-    archiveFileName = 'addressbook.jar'
+    archiveFileName = 'linkedup.jar'
 }
 
 defaultTasks 'clean', 'test'


### PR DESCRIPTION
The JAR archive filename was outdated.

Let's change the JAR archive filename to `linkedup.jar` to reflect the current project.