### PR TITLE
Add alert for attempt to add note in edit

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -125,6 +125,7 @@ public class EditCommand extends Command {
      */
     private static Person createEditedPerson(Person personToEdit, EditPersonDescriptor editPersonDescriptor) {
         assert personToEdit != null;
+        Objects.requireNonNull(editPersonDescriptor, "EditPersonDescriptor must not be null");
 
         Name updatedName = editPersonDescriptor.getName().orElse(personToEdit.getName());
         Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -5,10 +5,10 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/src/test/data/ExportTest/validJsonExport.json
+++ b/src/test/data/ExportTest/validJsonExport.json
@@ -1,21 +1,3 @@
 {
-  "persons" : [ {
-    "name" : "n",
-    "phone" : "12345786",
-    "telegram" : "",
-    "email" : "e@e.com",
-    "address" : "a",
-    "tags" : [ ],
-    "note" : "",
-    "isPinned" : false
-  }, {
-    "name" : "w",
-    "phone" : "12343827",
-    "telegram" : "",
-    "email" : "dfs@sfd.com",
-    "address" : "ds",
-    "tags" : [ ],
-    "note" : "",
-    "isPinned" : false
-  } ]
+  "persons" : [ ]
 }

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -24,6 +24,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -210,5 +211,12 @@ public class EditCommandParserTest {
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_notePrefixPresent_failure() {
+        // supplying note/ in edit should instruct user to use the note command instead
+        String userInput = "1 " + PREFIX_NOTE + "Some note";
+        assertParseFailure(parser, userInput, EditCommand.MESSAGE_NOTE_FORBIDDEN);
     }
 }


### PR DESCRIPTION
This pull request prevents users from editing notes using the `edit` command, enforcing that notes must be modified only through the dedicated `note` command. The changes add validation and user messaging to guide correct command usage.

**User input validation and messaging:**

* Added a new message `MESSAGE_NOTE_FORBIDDEN` in `EditCommand` to inform users that notes cannot be edited via the `edit` command and should be changed using the `note` command instead.
* Updated the `EditCommandParser` to include `PREFIX_NOTE` during argument tokenization, and added a check to throw a `ParseException` with `MESSAGE_NOTE_FORBIDDEN` if the note prefix is supplied in an edit command. [[1]](diffhunk://#diff-679694a67b9baa1949e346b32d50a81e557d9e1264574a45608a85ebc92f6452R11) [[2]](diffhunk://#diff-679694a67b9baa1949e346b32d50a81e557d9e1264574a45608a85ebc92f6452L43-R44) [[3]](diffhunk://#diff-679694a67b9baa1949e346b32d50a81e557d9e1264574a45608a85ebc92f6452R54-R58)

Closes #109 