### PR TITLE
Disable substring matching for keywords less than 4 chars

### DIFF
--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -49,8 +49,20 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
     }
 
     private boolean matchesKeyword(String word, String keyword, int threshold) {
-        return StringUtil.containsWordIgnoreCase(word, keyword)
-                || StringUtil.containsSubstringIgnoreCase(word, keyword)
-                || StringUtil.fuzzyMatch(word, keyword, threshold);
+        String trimmed = keyword.trim();
+        if (trimmed.isEmpty()) {
+            return false;
+        }
+
+        // For short keywords (length < 4) do NOT perform substring matching to avoid noisy matches.
+        if (trimmed.length() < 4) {
+            return StringUtil.containsWordIgnoreCase(word, trimmed)
+                    || StringUtil.fuzzyMatch(word, trimmed, threshold);
+        }
+
+        // For longer keywords allow substring matching in addition to full-word and fuzzy matches.
+        return StringUtil.containsWordIgnoreCase(word, trimmed)
+                || StringUtil.containsSubstringIgnoreCase(word, trimmed)
+                || StringUtil.fuzzyMatch(word, trimmed, threshold);
     }
 }


### PR DESCRIPTION
This pull request refines the keyword matching logic in `NameContainsKeywordsPredicate.java` to improve search relevance and reduce noisy results, especially for short keywords.

Improvements to keyword matching logic:

* Updated the `matchesKeyword` method to skip substring matching for keywords shorter than 4 characters, reducing false positives for short search terms.
* Added trimming and empty string checks to prevent unnecessary matching attempts on blank keywords.

Closes #145 